### PR TITLE
Let GROMACS runtime logs show use of Colvars build

### DIFF
--- a/cmake/gmxVersionInfo.cmake
+++ b/cmake/gmxVersionInfo.cmake
@@ -237,7 +237,7 @@ set(GMX_VERSION_STRING "${GMX_VERSION}${GMX_VERSION_SUFFIX}")
 # If you are distributing a patch to GROMACS, then this change would
 # be great as part of your patch. Otherwise for personal use, you can
 # also just set a CMake cache variable.
-set(GMX_VERSION_STRING_OF_FORK "" CACHE INTERNAL
+set(GMX_VERSION_STRING_OF_FORK "Colvars" CACHE INTERNAL
     "Version string for forks of GROMACS to set to describe themselves")
 mark_as_advanced(GMX_VERSION_STRING_OF_FORK)
 if (GMX_VERSION_STRING_OF_FORK)


### PR DESCRIPTION
Knowing that Colvars has patched the code and organized the build is
potentially valuable information for GROMACS users and developers
troubleshooting their runs.