### PR TITLE
Pass multisim record to Colvars for mwABF

### DIFF
--- a/src/external/colvars/colvarbias_abf.cpp
+++ b/src/external/colvars/colvarbias_abf.cpp
@@ -99,14 +99,16 @@ int colvarbias_abf::init(std::string const &conf)
   get_keyval(conf, "shared", shared_on, false);
   if (shared_on) {
     cvm::main()->cite_feature("Multiple-walker ABF implementation");
-    if ((proxy->replica_enabled() != COLVARS_OK) ||
-        (proxy->num_replicas() <= 1)) {
-      return cvm::error("Error: shared ABF requires more than one replica.",
-                        COLVARS_INPUT_ERROR);
+    // Do not check for replicas in Gromacs preprocessing, in VMD, etc.
+    if (proxy->simulation_running()) {
+      if (proxy->replica_enabled() != COLVARS_OK || proxy->num_replicas() <= 1) {
+        return cvm::error("Error: shared ABF requires more than one replica.",
+                          COLVARS_INPUT_ERROR);
+      } else {
+        cvm::log("shared ABF will be applied among "+
+                 cvm::to_str(proxy->num_replicas()) + " replicas.\n");
+      }
     }
-    cvm::log("shared ABF will be applied among "+
-             cvm::to_str(proxy->num_replicas()) + " replicas.\n");
-
     // If shared_freq is not set, we default to output_freq
     get_keyval(conf, "sharedFreq", shared_freq, output_freq);
   }

--- a/src/gromacs/applied_forces/colvars/colvarsforceprovider.cpp
+++ b/src/gromacs/applied_forces/colvars/colvarsforceprovider.cpp
@@ -53,6 +53,7 @@
 #include "gromacs/mdtypes/commrec.h"
 #include "gromacs/mdtypes/enerdata.h"
 #include "gromacs/mdtypes/forceoutput.h"
+#include "gromacs/mdrunutility/multisim.h"
 
 
 namespace gmx
@@ -155,11 +156,12 @@ ColvarsForceProvider::ColvarsForceProvider(const std::string& colvarsConfigStrin
                                            int                              seed,
                                            LocalAtomSetManager*             localAtomSetManager,
                                            const t_commrec*                 cr,
+                                           const gmx_multisim_t*            ms,
                                            double                           simulationTimeStep,
                                            const std::vector<RVec>&         colvarsCoords,
                                            const std::string&               outputPrefix,
                                            const ColvarsForceProviderState& state) :
-    ColvarProxyGromacs(colvarsConfigString, atoms, pbcType, logger, MAIN(cr), inputStrings, ensembleTemperature, seed),
+    ColvarProxyGromacs(colvarsConfigString, atoms, pbcType, logger, MAIN(cr), inputStrings, ensembleTemperature, seed, ms, true),
     stateToCheckpoint_(state)
 {
 

--- a/src/gromacs/applied_forces/colvars/colvarsforceprovider.h
+++ b/src/gromacs/applied_forces/colvars/colvarsforceprovider.h
@@ -49,7 +49,7 @@
 
 #include "colvarproxygromacs.h"
 
-
+struct gmx_multisim_t;
 namespace gmx
 {
 
@@ -178,6 +178,7 @@ public:
                          int                                       seed,
                          LocalAtomSetManager*                      localAtomSetManager,
                          const t_commrec*                          cr,
+                         const gmx_multisim_t*                     ms,
                          double                                    simulationTimeStep,
                          const std::vector<RVec>&                  colvarsCoords,
                          const std::string&                        outputPrefix,

--- a/src/gromacs/applied_forces/colvars/colvarspreprocessor.cpp
+++ b/src/gromacs/applied_forces/colvars/colvarspreprocessor.cpp
@@ -62,10 +62,11 @@ ColvarsPreProcessor::ColvarsPreProcessor(const std::string&   colvarsConfigStrin
                        true,
                        std::map<std::string, std::string>(),
                        ensembleTemperature,
-                       seed),
+                       seed,
+                       nullptr,
+                       false),
     x_(x)
 {
-
     // Initialize t_pbc struct
     set_pbc(&gmxPbc_, pbcType, box);
 

--- a/src/gromacs/applied_forces/colvars/colvarssimulationsparameters.cpp
+++ b/src/gromacs/applied_forces/colvars/colvarssimulationsparameters.cpp
@@ -112,6 +112,16 @@ const t_commrec* ColvarsSimulationsParameters::comm() const
     return cr_;
 }
 
+void ColvarsSimulationsParameters::setMultisim(const gmx_multisim_t *ms)
+{
+    ms_ = ms;
+}
+
+const gmx_multisim_t* ColvarsSimulationsParameters::ms() const
+{
+    return ms_;
+}
+
 
 void ColvarsSimulationsParameters::setLogger(const MDLogger& logger)
 {

--- a/src/gromacs/applied_forces/colvars/colvarssimulationsparameters.h
+++ b/src/gromacs/applied_forces/colvars/colvarssimulationsparameters.h
@@ -47,6 +47,7 @@
 #include "gromacs/pbcutil/pbc.h"
 #include "gromacs/topology/atoms.h"
 #include "gromacs/utility/logger.h"
+struct gmx_multisim_t;
 
 namespace gmx
 {
@@ -104,7 +105,12 @@ public:
     //! Return the communicator
     const t_commrec* comm() const;
 
-    /*! \brief Set the logger for QMMM during mdrun
+    //! Set the Multisim record
+    void setMultisim(const gmx_multisim_t *ms);
+    //! Return Multisim record
+    const gmx_multisim_t* ms() const;
+
+    /*! \brief Set the logger for Colvars during mdrun
      * \param[in] logger Logger instance to be used for output
      */
     void setLogger(const MDLogger& logger);
@@ -123,6 +129,8 @@ private:
     t_atoms gmxAtoms_;
     //! The communicator
     const t_commrec* cr_;
+    //! The multisim record
+    const gmx_multisim_t *ms_;
     //! MDLogger for notifications during mdrun
     const MDLogger* logger_ = nullptr;
 

--- a/src/gromacs/mdrun/runner.cpp
+++ b/src/gromacs/mdrun/runner.cpp
@@ -1795,6 +1795,7 @@ int Mdrunner::mdrunner()
     if (thisRankHasDuty(cr, DUTY_PP))
     {
         setupNotifier.notify(*cr);
+        setupNotifier.notify(ms);
         setupNotifier.notify(&atomSets);
         setupNotifier.notify(mtop);
         setupNotifier.notify(inputrec->pbcType);

--- a/src/gromacs/mdrunutility/mdmodulesnotifiers.h
+++ b/src/gromacs/mdrunutility/mdmodulesnotifiers.h
@@ -58,6 +58,7 @@ struct gmx_mtop_t;
 class WarningHandler;
 enum class PbcType : int;
 struct t_inputrec;
+struct gmx_multisim_t;
 
 namespace gmx
 {
@@ -374,6 +375,7 @@ struct MDModulesNotifiers
                            SeparatePmeRanksPermitted*,
                            const PbcType&,
                            const SimulationTimeStep&,
+                           const gmx_multisim_t*,
                            const t_commrec&,
                            const MdRunInputFilename&,
                            const EdrOutputFilename&>::type simulationSetupNotifier_;


### PR DESCRIPTION
This PR is for sharing, testing, and discussion. Changes will be contributed to the main Colvars and Gromacs repositories.

The MPI-based replica communication routines are now shared by Gromacs, LAMMPS, and Tinker-HP. Ultimately they should go into the proxy base class, however, we may need to play with the build system of the various codes to make sure that the base class compiles correctly with and without MPI present. I haven't yet found a clean way to achieve that, so I've replicated the (short) code.